### PR TITLE
fixed final failing test

### DIFF
--- a/tests/test_project_input.py
+++ b/tests/test_project_input.py
@@ -328,8 +328,9 @@ def test_run_scan_flow_with_real_timestamps(tmp_path):
     # Verify timestamps are not None and contain recent date
     assert stored_created is not None
     assert stored_modified is not None
-    assert "2025" in str(stored_created)  # Should be current year
-    assert "2025" in str(stored_modified)
+    current_year = str(datetime.now().year)
+    assert current_year in str(stored_created) 
+    assert current_year in str(stored_modified)
 
 def test_store_project_without_timestamps_uses_defaults(tmp_path):
     """Test that when no timestamps are provided, current time is used."""


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR updates the final failing test case that was initially failing due to a harded coded year (2025) and now replaces the hardcoded code using the current year. This way, we wont have to update it every year.


> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

**Closes:** #503 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [x] test_run_scan_flow_with_real_timestamps

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="1004" height="67" alt="Screenshot 2026-01-21 at 2 40 04 PM" src="https://github.com/user-attachments/assets/e96fd3f0-b6eb-4808-98d1-b28bb075102f" />

</details>
