### PR TITLE
Feature 28: Added Endpoint for deleting edited resumes. 

### DIFF
--- a/app/api/routes/resume.py
+++ b/app/api/routes/resume.py
@@ -287,7 +287,7 @@ def delete_saved_resume(resume_id: int):
         
         return {
             "success": True,
-            "message": f"Resume {resume_id} ({resume[0] if resume else 'Unknown'}) deleted successfully",
+            "message": f"Resume {resume_id} deleted successfully",
             "deleted_resume_id": resume_id
         }
         


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This pull request implements a DELETE endpoint for removing saved and edited resumes from the system. The endpoint allows users to delete custom resume versions that they have previously created and edited, while preserving the master resume data and base project information.

**Closes:** #578 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

The implementation has been tested with a comprehensive test suite that validates all aspects of the DELETE endpoint functionality. The tests use mocking to simulate database interactions and verify that the endpoint correctly handles various scenarios including successful deletions, missing resumes, and database errors.


---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> All tests pass:

<img width="860" height="418" alt="Screenshot 2026-02-02 at 12 21 02 AM" src="https://github.com/user-attachments/assets/f1fa8a52-3ed1-4875-81a7-d4b5464b639c" />

