### PR TITLE
Project Score Override Utils

### DIFF
--- a/app/utils/score_override_utils.py
+++ b/app/utils/score_override_utils.py
@@ -43,7 +43,7 @@ def resolve_effective_score(
     Resolve base/override/effective values for consistent API/retrieve display.
     """
     score_original = _to_float(score, 0.0)
-    is_overridden = bool(score_overridden)
+    is_overridden = _to_int(score_overridden, 0) == 1
     overridden_value = (
         _to_float(score_overridden_value)
         if score_overridden_value is not None
@@ -87,7 +87,7 @@ def get_project_score_state_map(
     states: Dict[str, Dict[str, Any]] = {}
     for project_signature, score_overridden, score_overridden_value in cursor.fetchall():
         states[project_signature] = {
-            "score_overridden": bool(score_overridden),
+            "score_overridden": _to_int(score_overridden, 0) == 1,
             "score_overridden_value": (
                 _to_float(score_overridden_value)
                 if score_overridden_value is not None
@@ -306,6 +306,9 @@ def apply_project_score_override(
         if cursor.rowcount <= 0:
             raise ProjectNotFoundError("Project not found")
         conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 

--- a/tests/utils/test_score_override_utils.py
+++ b/tests/utils/test_score_override_utils.py
@@ -83,6 +83,16 @@ def test_resolve_effective_score_overridden():
     assert resolved["display_score"] == pytest.approx(0.95)
 
 
+def test_resolve_effective_score_string_override_flags():
+    not_overridden = resolve_effective_score(0.7, "0", 0.95)
+    assert not_overridden["score_overridden"] is False
+    assert not_overridden["display_score"] == pytest.approx(0.7)
+
+    overridden = resolve_effective_score(0.7, "1", 0.95)
+    assert overridden["score_overridden"] is True
+    assert overridden["display_score"] == pytest.approx(0.95)
+
+
 def test_compute_project_breakdown_non_git(isolated_db):
     signature = _insert_non_git_project()
     payload = compute_project_breakdown(signature)


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

Adds the core score-override backend utility and focused unit tests for override behavior.

This PR introduces, which centralizes:
- effective/display score resolution (score, score_original, override fields)
- project score breakdown computation from persisted DB metrics
- score override preview (non-persistent)
- score override apply (persistent)
- score override clear/reset (persistent)
- shared validation/not-found exceptions for callers

Note: The PR is slightly greater than 500 lines since the test and utils come from a single backend and are best maintained in a single PR for implementation and understanding changes.

**Closes:** #663

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Test coverage includes:
- non-overridden and overridden score resolution
- breakdown computation for valid project data
- preview with metric exclusion
- validation when all code metrics are excluded
- apply override persistence in DB
- clear override persistence in DB
- project not found path

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<img width="972" height="186" alt="image" src="https://github.com/user-attachments/assets/46523114-6619-4572-970d-a3cc18aba8f1" />